### PR TITLE
Try to catch and return error that was triggered in stream after destroy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
 node_js:
   - "0.10"
+  - "0.12"
+  - "4"
 
 script: "npm test"
+sudo: false

--- a/index.js
+++ b/index.js
@@ -20,11 +20,11 @@ var destroyer = function(stream, reading, writing, callback) {
 	var streamError = null;
 	callback = once(callback);
 
-	var closed = false;
 	stream.on('error', function(err) {
 		streamError = err;
 	});
 
+	var closed = false;
 	stream.on('close', function() {
 		closed = true;
 	});
@@ -48,14 +48,14 @@ var destroyer = function(stream, reading, writing, callback) {
 		if (isFS(stream)) return stream.close(); // use close for fs streams to avoid fd leaks
 		if (isRequest(stream)) return stream.abort(); // request.destroy just do .end - .abort is what we want
 
-		if (isFn(stream.destroy)) return stream.destroy();
+		if (isFn(stream.destroy)) return stream.destroy(err);
 
 		callback(err || new Error('stream was destroyed'));
 	};
 };
 
-var call = function(fn) {
-	fn();
+var call = function(err, fn) {
+	fn(err);
 };
 
 var pipe = function(from, to) {
@@ -75,9 +75,9 @@ var pump = function() {
 		var writing = i > 0;
 		return destroyer(stream, reading, writing, function(err) {
 			if (!error) error = err;
-			if (err) destroys.forEach(call);
+			if (err) destroys.forEach(call.bind(this, err));
 			if (reading) return;
-			destroys.forEach(call);
+			destroys.forEach(call.bind(this, null));
 			callback(error);
 		});
 	});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pump",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "repository": "git://github.com/mafintosh/pump.git",
   "license": "MIT",
   "description": "pipe streams together and close all of them if one of them closes",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pump",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "repository": "git://github.com/mafintosh/pump.git",
   "license": "MIT",
   "description": "pipe streams together and close all of them if one of them closes",

--- a/test.js
+++ b/test.js
@@ -1,4 +1,3 @@
-var assert = require('assert');
 var pump = require('./index');
 
 var rs = require('fs').createReadStream('/dev/random');
@@ -18,10 +17,11 @@ var toHex = function() {
 var wsClosed = false;
 var rsClosed = false;
 var callbackCalled = false;
-var error = null;
+var cbError = null;
+var tsError = null;
 
 var check = function() {
-	if (wsClosed && rsClosed && callbackCalled && error === "Error from stream" ) process.exit(0);
+	if (wsClosed && rsClosed && callbackCalled && cbError === tsError && cbError === "Error from stream") process.exit(0);
 };
 
 ws.on('close', function() {
@@ -34,8 +34,13 @@ rs.on('close', function() {
 	check();
 });
 
-pump(rs, toHex(), toHex(), toHex(), ws, function(err) {
-	error = err;
+var ts = toHex();
+ts.destroy = function(err) {
+	tsError = err;
+};
+
+pump(rs, toHex(), toHex(), ts, ws, function(err) {
+	cbError = err;
 	callbackCalled = true;
 	check();
 });

--- a/test.js
+++ b/test.js
@@ -18,9 +18,10 @@ var toHex = function() {
 var wsClosed = false;
 var rsClosed = false;
 var callbackCalled = false;
+var error = null;
 
 var check = function() {
-	if (wsClosed && rsClosed && callbackCalled) process.exit(0);
+	if (wsClosed && rsClosed && callbackCalled && error === "Error from stream" ) process.exit(0);
 };
 
 ws.on('close', function() {
@@ -34,12 +35,14 @@ rs.on('close', function() {
 });
 
 pump(rs, toHex(), toHex(), toHex(), ws, function(err) {
+	error = err;
 	callbackCalled = true;
 	check();
 });
 
 setTimeout(function() {
 	rs.destroy();
+	rs.emit('error', "Error from stream");
 }, 1000);
 
 setTimeout(function() {


### PR DESCRIPTION
Some of the streams are emmiting errors after they destroy stream, so currenctly pump will show only error about stream destruction. For instance MongoDB Native driver is doing that
https://github.com/mongodb/node-mongodb-native/blob/2.0/lib/cursor.js#L1014
```javascript
Cursor.prototype.destroy = function(err) {
  this.pause();
  this.close();
  if(err) this.emit('error', err);
}
```
And here is example how to reproduce the problem 

```javascript
var MongoClient = require('mongodb').MongoClient;
var url = 'mongodb://localhost:27017/development';
var pump = require('pump');

MongoClient.connect(url, function (err, db) {
	if (err) throw err
	console.log('connected');

	var cursor = db.collection('locks').find({
		timestamp: { $weLoveAlessandro: 'true' } // Error in query.
	});

	pump(cursor, process.stdout, function (err) {
		console.log("ERR from pump", err); //ERR from pump [Error: premature close] (returned by eos)
	});
});
```
So this PR makes the error to be actual error: 
```
ERR from pump { [MongoError: Can't canonicalize query: BadValue unknown operator: $weLoveAlessandro]
  name: 'MongoError',
  message: 'Can\'t canonicalize query: BadValue unknown operator: $weLoveAlessandro',
  '$err': 'Can\'t canonicalize query: BadValue unknown operator: $weLoveAlessandro',
  code: 17287 }
```
Additionaly it destroys streams with original error