### PR TITLE
Avoid `ERR_INVALID_ARG_TYPE` error on Node.js >= 9

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ var destroyer = function (stream, reading, writing, callback) {
     if (destroyed) return
     destroyed = true
 
-    if (isFS(stream)) return stream.close() // use close for fs streams to avoid fd leaks
+    if (isFS(stream)) return stream.close(noop) // use close for fs streams to avoid fd leaks
     if (isRequest(stream)) return stream.abort() // request.destroy just do .end - .abort is what we want
 
     if (isFn(stream.destroy)) return stream.destroy()


### PR DESCRIPTION
### Problem

From https://github.com/nodejs/node/commit/e5c290bed9775bdddd74650995f3358373af8097 that is shipped with Node.js 9, [`fs.WriteStream#close()`](https://github.com/nodejs/node/blob/1b093cb93df05bea0c9adfb6a060d2a4542c1ae0/lib/fs.js#L2300) requires a callback function as its first argument and throws an error when no arguments are provided to it.

Here is a small example to reproduce the error:

```js
'use strict';

const {createWriteStream} = require('fs');
const {PassThrough} = require('stream');
const pump = require('pump');

const firstStream = new PassThrough();
firstStream.end(Buffer.alloc(99999999));

pump([
  firstStream,
  // Writing contents to `__dirname` should always fail with EISDIR error.
  createWriteStream(__dirname)
], err => {
  console.log(err.message);
});
```

With Node.js 8.9.1, it works as expected.

```console
$ node --version
v8.9.1

$ node exmaple.js
EISDIR: illegal operation on a directory, open '/Users/shinnn/github/pump'
```

But with Node.js 9.2.0, it throws a `TypeError` like below:

```console
$ node --version
v9.2.0

$ node exmaple.js
events.js:180
    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'listener', 'Function');
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "listener" argument must be of type Function
    at _addListener (events.js:180:11)
    at WriteStream.addListener (events.js:240:10)
    at WriteStream.close (fs.js:2302:10)
    at /Users/shinnn/github/pump/index.js:40:37
    at call (/Users/shinnn/github/pump/index.js:50:3)
    at Array.forEach (<anonymous>)
    at /Users/shinnn/github/pump/index.js:70:25
    at f (/Users/shinnn/github/pump/node_modules/once/once.js:25:25)
    at WriteStream.<anonymous> (/Users/shinnn/github/pump/index.js:29:21)
    at WriteStream.f (/Users/shinnn/github/pump/node_modules/once/once.js:25:25)
```

### Solution

I added a noop function to the `fs.WriteStream#close()` argument to avoid the `ERR_INVALID_ARG_TYPE` error.
