### PR TITLE
Bug: Feat/return last stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ pump(source, transform, anotherTransform, dest, function(err) {
 
 If `source`, `transform`, `anotherTransform` or `dest` closes all of them will be destroyed.
 
-Similarly to `.pipe` works, `pump()` returns the last stream passed in, so you can do:
+Similarly to `stream.pipe()`, `pump()` returns the last stream passed in, so you can do:
 
 ```
 return pump(s1, s2) // returns s2

--- a/README.md
+++ b/README.md
@@ -47,7 +47,11 @@ pump(source, transform, anotherTransform, dest, function(err) {
 
 If `source`, `transform`, `anotherTransform` or `dest` closes all of them will be destroyed.
 
-`pump()` returns the last stream passed in.
+Similarly to `.pipe` works, `pump()` returns the last stream passed in, so you can do:
+
+```
+return pump(s1, s2) // returns s2
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ pump(source, transform, anotherTransform, dest, function(err) {
 
 If `source`, `transform`, `anotherTransform` or `dest` closes all of them will be destroyed.
 
+`pump()` returns the last stream passed in.
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ var pump = function () {
     })
   })
 
-  streams.reduce(pipe)
+  return streams.reduce(pipe)
 }
 
 module.exports = pump

--- a/test-browser.js
+++ b/test-browser.js
@@ -43,10 +43,14 @@ rs.on('end', function () {
   check()
 })
 
-pump(rs, toHex(), toHex(), toHex(), ws, function () {
+var res = pump(rs, toHex(), toHex(), toHex(), ws, function () {
   callbackCalled = true
   check()
 })
+
+if (res !== ws) {
+  throw new Error('should return last stream')
+}
 
 setTimeout(function () {
   rs.push(null)

--- a/test.js
+++ b/test.js
@@ -53,7 +53,7 @@ if (res !== ws) {
   throw new Error('should return last stream')
 }
 
-// Don't return streams
+// Returned stream swallows errors
 var rs2 = require('fs').createReadStream('/dev/random')
 var ws2 = require('fs').createWriteStream('/dev/null')
 
@@ -63,9 +63,24 @@ eos(pump(rs2, withErr(), ws2), function(err) {
   }
 })
 
+// Native .pipe rethrows errors
+var rs3 = require('fs').createReadStream('/dev/random')
+var ws3 = require('fs').createWriteStream('/dev/null')
+
+process.once('uncaughtException', function(err) {
+  err.message === 'Fail'
+})
+
+eos(rs3.pipe(withErr()).pipe(ws3), function(err) {
+  if (!err) {
+    throw new Error('should propagate error on stream')
+  }
+})
+
 setTimeout(function () {
   rs.destroy()
   rs2.destroy()
+  rs3.destroy()
 }, 1000)
 
 setTimeout(function () {

--- a/test.js
+++ b/test.js
@@ -37,8 +37,8 @@ var res = pump(rs, toHex(), toHex(), toHex(), ws, function () {
   check()
 })
 
-if (res) {
-  process.exit(1);
+if (res !== ws) {
+  throw new Error('should return last stream')
 }
 
 setTimeout(function () {

--- a/test.js
+++ b/test.js
@@ -1,5 +1,7 @@
 var pump = require('./index')
 
+var eos = require('end-of-stream')
+
 var rs = require('fs').createReadStream('/dev/random')
 var ws = require('fs').createWriteStream('/dev/null')
 
@@ -12,6 +14,16 @@ var toHex = function () {
   }
 
   return reverse
+}
+
+var withErr = function() {
+  var errs = new (require('stream').Transform)()
+
+  errs._transform = function (chunk, enc, callback) {
+    callback(new Error('Fails'))
+  }
+
+  return errs
 }
 
 var wsClosed = false
@@ -41,8 +53,19 @@ if (res !== ws) {
   throw new Error('should return last stream')
 }
 
+// Don't return streams
+var rs2 = require('fs').createReadStream('/dev/random')
+var ws2 = require('fs').createWriteStream('/dev/null')
+
+eos(pump(rs2, withErr(), ws2), function(err) {
+  if (!err) {
+    throw new Error('should propagate error on stream')
+  }
+})
+
 setTimeout(function () {
   rs.destroy()
+  rs2.destroy()
 }, 1000)
 
 setTimeout(function () {


### PR DESCRIPTION
@mafintosh @pgte this demonstrates the problem with what you are suggesting.  It's not the proper or expected behavior of the stream to not emit errors.  If you use pumpify, you have this desired behavior **and** it propagates the errors.  What is the reason for attempting to duplicate the behavior from pumpify?