### PR TITLE
Re-emit errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ var pipe = function (from, to) {
 
 var pump = function () {
   var streams = Array.prototype.slice.call(arguments)
-  var callback = isFn(streams[streams.length - 1] || noop) && streams.pop() || noop
+  var callback = isFn(streams[streams.length - 1] || noop) && streams.pop()
 
   if (Array.isArray(streams[0])) streams = streams[0]
   if (streams.length < 2) throw new Error('pump requires two streams per minimum')
@@ -72,6 +72,7 @@ var pump = function () {
       if (err) destroys.forEach(call)
       if (reading) return
       destroys.forEach(call)
+      if (error && !callback) return stream.emit('error', error)
       callback(error)
     })
   })

--- a/test-node.js
+++ b/test-node.js
@@ -1,5 +1,7 @@
 var pump = require('./index')
 
+var eos = require('end-of-stream')
+
 var rs = require('fs').createReadStream('/dev/random')
 var ws = require('fs').createWriteStream('/dev/null')
 
@@ -12,6 +14,16 @@ var toHex = function () {
   }
 
   return reverse
+}
+
+var withErr = function(msg) {
+  var errs = new (require('stream').Transform)()
+
+  errs._transform = function (chunk, enc, callback) {
+    callback(new Error(msg))
+  }
+
+  return errs
 }
 
 var wsClosed = false
@@ -44,8 +56,38 @@ if (res !== ws) {
   throw new Error('should return last stream')
 }
 
+// Returned stream swallows errors
+var rs2 = require('fs').createReadStream('/dev/random')
+var ws2 = require('fs').createWriteStream('/dev/null')
+
+process.once('uncaughtException', function(err) {
+  err.message === 'Pump Fail'
+})
+
+eos(pump(rs2, withErr('Pump Fail'), ws2), function(err) {
+  if (!err) {
+    throw new Error('should propagate error on stream')
+  }
+})
+
+// Native .pipe rethrows errors
+var rs3 = require('fs').createReadStream('/dev/random')
+var ws3 = require('fs').createWriteStream('/dev/null')
+
+process.once('uncaughtException', function(err) {
+  err.message === 'Pipe Fail'
+})
+
+eos(rs3.pipe(withErr('Pipe Fail')).pipe(ws3), function(err) {
+  if (!err) {
+    throw new Error('should propagate error on stream')
+  }
+})
+
 setTimeout(function () {
   rs.destroy()
+  rs2.destroy()
+  rs3.destroy()
 }, 1000)
 
 var timeout = setTimeout(function () {


### PR DESCRIPTION
@mafintosh can we do something like this to re-emit errors that occur if a user doesn't specify a callback instead of using the noop?