### PR TITLE
Add stream index to errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ setTimeout(function() {
 }, 1000)
 ```
 
+If an `err` is returned in the callback it will have a `streamIndex` property indicating from which stream the error originated from.
+
 You can use pump to pipe more than two streams together as well
 
 ``` js

--- a/index.js
+++ b/index.js
@@ -68,7 +68,10 @@ var pump = function () {
     var reading = i < streams.length - 1
     var writing = i > 0
     return destroyer(stream, reading, writing, function (err) {
-      if (!error) error = err
+      if (!error && err) {
+        error = err
+        error.streamIndex = i
+      }
       if (err) destroys.forEach(call)
       if (reading) return
       destroys.forEach(call)

--- a/test-node-error.js
+++ b/test-node-error.js
@@ -1,0 +1,23 @@
+var pump = require('./index')
+
+var rs = require('fs').createReadStream('/dev/random')
+var ws = require('fs').createWriteStream('/dev/null')
+
+var callbackCalled = false
+
+var check = function (err) {
+  if (err && err.streamIndex === 0) {
+    console.log('test-node-error.js passes')
+    clearTimeout(timeout)
+  }
+}
+
+setTimeout(function () {
+  rs.destroy(new Error('premature close'))
+}, 1000)
+
+pump(rs, ws, check)
+
+var timeout = setTimeout(function () {
+  throw new Error('timeout')
+}, 5000)


### PR DESCRIPTION
When an error is returned to the callback of pump, it would be nice to know which stream was the cause of the error if you want to add some custom handling of the error depending on which stream caused the error.

Therefore this PR adds a 'streamIndex' property to errors returned to callback, so that you can easily determine which stream caused the error.