### PR TITLE
fix: add judgment condition

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ var pump = function () {
       if (!error) error = err
       if (err) destroys.forEach(call)
       if (reading) return
-      destroys.forEach(call)
+      if (!err) destroys.forEach(call)
       callback(error)
     })
   })


### PR DESCRIPTION
```if (!err) destroys.forEach(call)```
Without this judgment, when err is true, destroys.forEach will be executed twice, the second time is not necessary.