### PR TITLE
Specify files to publish to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   },
   "scripts": {
     "test": "node test-browser.js && node test-node.js"
-  }
+  },
+  "files": [
+    "index.js"
+  ]
 }


### PR DESCRIPTION
Currently test and `.travis.yml` are being published to npm. This PR excludes them using the using the [`files`](https://docs.npmjs.com/files/package.json#files) whitelist in the `package.json` and saves a few bytes whenever you download this package.