### PR TITLE
Only check if ancient when not in browser

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,15 +3,17 @@ var eos = require('end-of-stream')
 var fs = require('fs') // we only need fs to get the ReadStream and WriteStream prototypes
 
 var noop = function () {}
-var ancient = /^v?\.0/.test(process.version)
 
 var isFn = function (fn) {
   return typeof fn === 'function'
 }
 
 var isFS = function (stream) {
-  if (!ancient) return false // newer node version do not need to care about fs is a special way
   if (!fs) return false // browser
+
+  var ancient = /^v?\.0/.test(process.version)
+  if (!ancient) return false // newer node version do not need to care about fs is a special way
+  
   return (stream instanceof (fs.ReadStream || noop) || stream instanceof (fs.WriteStream || noop)) && isFn(stream.close)
 }
 


### PR DESCRIPTION
I've moved the ancient check to be after the browser check to bypass the browser error:

index.js:6 Uncaught ReferenceError: process is not defined
    at ../../node_modules/pump/index.js (index.js:6:29)
    at __require2 (chunk-KQHTJEE7.js:18:50)
    at utils.ts:25:2