### PR TITLE
Remove once dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,14 @@
-var once = require('once')
 var eos = require('end-of-stream')
 var fs
+
+var once = function (fn) {
+  var called = false
+  return function () {
+    if (called) return
+    called = true
+    return fn.apply(this, arguments)
+  }
+}
 
 try {
   fs = require('fs') // we only need fs to get the ReadStream and WriteStream prototypes

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
   ],
   "author": "Mathias Buus Madsen <mathiasbuus@gmail.com>",
   "dependencies": {
-    "end-of-stream": "^1.1.0",
-    "once": "^1.3.1"
+    "end-of-stream": "^1.1.0"
   },
   "scripts": {
     "test": "node test-browser.js && node test-node.js"

--- a/test-browser.js
+++ b/test-browser.js
@@ -27,10 +27,10 @@ var toHex = function () {
 
 var wsClosed = false
 var rsClosed = false
-var callbackCalled = false
+var callbackCount = 0
 
 var check = function () {
-  if (wsClosed && rsClosed && callbackCalled) {
+  if (wsClosed && rsClosed && callbackCount === 1) {
     console.log('test-browser.js passes')
     clearTimeout(timeout)
   }
@@ -47,7 +47,8 @@ rs.on('end', function () {
 })
 
 var res = pump(rs, toHex(), toHex(), toHex(), ws, function () {
-  callbackCalled = true
+  callbackCount++
+  if (callbackCount > 1) throw new Error('pump callback called more than once')
   check()
 })
 
@@ -64,3 +65,32 @@ var timeout = setTimeout(function () {
   check()
   throw new Error('timeout')
 }, 5000)
+
+// Test: callback fires only once when a transform errors mid-pipeline
+;(function () {
+  var rs2 = new stream.Readable()
+  var ws2 = new stream.Writable()
+  var ts = new stream.Transform()
+
+  rs2._read = function () {
+    this.push(Buffer.alloc(64).fill('x'))
+  }
+
+  var count = 0
+  ts._transform = function (chunk, enc, next) {
+    count++
+    if (count === 3) return next(new Error('transform error'))
+    this.push(chunk)
+    next()
+  }
+
+  ws2._write = function (chunk, enc, next) {
+    next()
+  }
+
+  var errorCallbackCount = 0
+  pump(rs2, ts, ws2, function () {
+    errorCallbackCount++
+    if (errorCallbackCount > 1) throw new Error('error pump callback called more than once')
+  })
+})()

--- a/test-node.js
+++ b/test-node.js
@@ -16,10 +16,10 @@ var toHex = function () {
 
 var wsClosed = false
 var rsClosed = false
-var callbackCalled = false
+var callbackCount = 0
 
 var check = function () {
-  if (wsClosed && rsClosed && callbackCalled) {
+  if (wsClosed && rsClosed && callbackCount === 1) {
     console.log('test-node.js passes')
     clearTimeout(timeout)
   }
@@ -36,7 +36,8 @@ rs.on('close', function () {
 })
 
 var res = pump(rs, toHex(), toHex(), toHex(), ws, function () {
-  callbackCalled = true
+  callbackCount++
+  if (callbackCount > 1) throw new Error('pump callback called more than once')
   check()
 })
 


### PR DESCRIPTION
Replace `once` (and its transitive dependency `wrappy`) with a local
implementation.

`once` is used in a single place in this codebase to guard the
destroyer callback. The same behavior is expressed in 7 lines without
the two extra packages in the dependency tree.

Existing tests are updated to verify the pump callback fires exactly
once, and a new transform-error scenario is added to test-browser.js.

Related: https://github.com/e18e/ecosystem-issues/issues/208